### PR TITLE
Add minimal HTTP proxy for Proxifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Mobile IP Browser Proxy
+
+This repository includes a minimal HTTP proxy (`simple_proxy.py`).
+Run it first and then point Proxifier at the proxy using these settings:
+
+1. **Proxy Server**
+   - Address: `127.0.0.1`
+   - Port: `8080` (or the value of the `PROXY_PORT` environment variable)
+   - Protocol: **HTTP**
+
+2. **Proxy Rules** (in priority order)
+   1. `Localhost` – destination addresses `127.0.0.1`/`::1` – **Direct**
+   2. `Local Network` – destination addresses in `10.0.0.0/8`,
+      `172.16.0.0/12`, or `192.168.0.0/16` – **Direct**
+   3. `IP Verification Sites` – domains `ipinfo.io`, `api.ipify.org`,
+      `ifconfig.me`, `icanhazip.com`, `checkip.amazonaws.com` – **Proxy**
+   4. `Streaming Sites` – domains `twitch.tv`, `youtube.com` – **Proxy**
+   5. `Default` – all other traffic – **Direct**
+
+Set the rules in this order so verification and streaming traffic
+is routed through the proxy while all other traffic goes directly.
+The proxy listens on `127.0.0.1:8080` by default but you can override the port
+with the `PROXY_PORT` environment variable.  Set `PROXY_DYNAMIC=true` if you
+need the script to allocate multiple proxy ports.
+
+Start the proxy with:
+
+```
+python3 simple_proxy.py
+```
+
+After the proxy is running, launch the main script:
+
+```
+python3 mobile_ip_browser
+```

--- a/mobile_ip_browser
+++ b/mobile_ip_browser
@@ -60,7 +60,13 @@ logging.basicConfig(
 logger = logging.getLogger("ip_preserver")
 
 # Global variables
-PROXY_PORT_START = 8080
+# PROXY_PORT allows overriding the default proxy port via environment variable.
+# When set, all sessions will use this fixed port so the Proxifier rule only
+# needs to point to a single HTTP proxy.
+DEFAULT_PROXY_PORT = 8080
+PROXY_PORT = int(os.getenv("PROXY_PORT", DEFAULT_PROXY_PORT))
+PROXY_DYNAMIC_PORTS = os.getenv("PROXY_DYNAMIC", "false").lower() == "true"
+PROXY_PORT_START = PROXY_PORT
 DNS_PORT_START = 10053
 active_proxies = {}  # port -> {server, thread, ip}
 active_dns_servers = {}  # port -> {server, thread, ip}
@@ -2222,10 +2228,12 @@ def start_identity_proxy(identity_ip, tether_interface=None, tether_ip=None):
             logger.info(f"Using existing proxy for IP {identity_ip} on port {port}")
             return port
     
-    # Try up to 5 different ports in case of conflicts
-    for attempt in range(1, 6):
+    # Use a single fixed port unless PROXY_DYNAMIC_PORTS is enabled
+    max_attempts = 5 if PROXY_DYNAMIC_PORTS else 1
+    for attempt in range(1, max_attempts + 1):
         port = PROXY_PORT_START
-        PROXY_PORT_START += 1
+        if PROXY_DYNAMIC_PORTS:
+            PROXY_PORT_START += 1
         
         logger.info(f"Attempt {attempt}: Starting proxy on port {port} for IP {identity_ip}")
         
@@ -2236,8 +2244,12 @@ def start_identity_proxy(identity_ip, tether_interface=None, tether_ip=None):
             sock.close()
             
             if result == 0:
-                logger.warning(f"Port {port} is already in use, trying another port")
-                continue
+                if PROXY_DYNAMIC_PORTS:
+                    logger.warning(f"Port {port} is already in use, trying another port")
+                    continue
+                else:
+                    logger.error(f"Port {port} is already in use")
+                    return None
             
             # Create a proxy server that binds outgoing connections to tethering interface if available
             server = IPIdentityProxyServer(('127.0.0.1', port), IPIdentityProxyHandler, identity_ip, tether_interface)

--- a/simple_proxy.py
+++ b/simple_proxy.py
@@ -1,0 +1,86 @@
+import os
+import socket
+import select
+import socketserver
+from http.server import BaseHTTPRequestHandler
+import urllib.request
+
+class ProxyRequestHandler(BaseHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+
+    def do_CONNECT(self):
+        host, port = self.path.split(':')
+        try:
+            port = int(port)
+        except ValueError:
+            self.send_error(400, 'Invalid port')
+            return
+        try:
+            remote = socket.create_connection((host, port))
+        except OSError as e:
+            self.send_error(502, str(e))
+            return
+
+        self.send_response(200, 'Connection Established')
+        self.end_headers()
+
+        sockets = [self.connection, remote]
+        while True:
+            rlist, _, _ = select.select(sockets, [], [])
+            if self.connection in rlist:
+                data = self.connection.recv(8192)
+                if not data:
+                    break
+                remote.sendall(data)
+            if remote in rlist:
+                data = remote.recv(8192)
+                if not data:
+                    break
+                self.connection.sendall(data)
+        remote.close()
+        self.connection.close()
+
+    def do_GET(self):
+        self._proxy_request()
+
+    def do_POST(self):
+        self._proxy_request()
+
+    def do_PUT(self):
+        self._proxy_request()
+
+    def do_DELETE(self):
+        self._proxy_request()
+
+    def _proxy_request(self):
+        url = self.path
+        if not url.startswith('http'):
+            url = f"http://{self.headers['Host']}{url}"
+        data = None
+        if 'Content-Length' in self.headers:
+            length = int(self.headers['Content-Length'])
+            data = self.rfile.read(length)
+        headers = {k: v for k, v in self.headers.items() if k.lower() != 'proxy-connection'}
+        req = urllib.request.Request(url, data=data, headers=headers, method=self.command)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                body = resp.read()
+                self.send_response(resp.status)
+                for k, v in resp.getheaders():
+                    if k.lower() != 'transfer-encoding':
+                        self.send_header(k, v)
+                self.end_headers()
+                self.wfile.write(body)
+        except Exception as e:
+            self.send_error(502, str(e))
+
+
+def run():
+    port = int(os.environ.get('PROXY_PORT', '8080'))
+    with socketserver.ThreadingTCPServer(('127.0.0.1', port), ProxyRequestHandler) as httpd:
+        print(f"Simple proxy listening on 127.0.0.1:{port}")
+        httpd.serve_forever()
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
## Summary
- add `simple_proxy.py` providing a lightweight HTTP proxy with CONNECT support
- document how to start the proxy and run the main script

## Testing
- `python3 -m py_compile mobile_ip_browser simple_proxy.py`